### PR TITLE
Fix list_tasks docstring typo

### DIFF
--- a/tasks/reminder_task_manager.py
+++ b/tasks/reminder_task_manager.py
@@ -79,7 +79,7 @@ class ReminderTaskManager:
 
     def list_tasks(self, user_id: str) -> list:
         """
-        Returns a list of the user�s tasks/reminders.
+        Returns a list of the user’s tasks/reminders.
         """
         tasks = self.load_tasks_for_user(user_id)
         return tasks.get("tasks", [])


### PR DESCRIPTION
## Summary
- correct text encoding in `list_tasks` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f8df7dac8330a8cbe009ff475ebf