### PR TITLE
Fix paths to use configuration constants

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -715,9 +715,10 @@ def get_message_categories():
         raise
 
 def load_default_messages(category):
-    default_messages_file = os.path.join("C:/Users/Julie/projects/MHM/MHM/default_messages", f"{category}.json")
+    """Load default messages for the given category."""
+    default_messages_file = os.path.join(DEFAULT_MESSAGES_DIR_PATH, f"{category}.json")
     try:
-        with open(default_messages_file, 'r') as file:
+        with open(default_messages_file, 'r', encoding='utf-8') as file:
             default_messages = json.load(file)
             logger.debug(f"Loaded default messages for category {category}")
             return default_messages
@@ -895,7 +896,7 @@ def get_last_10_messages(user_id, category):
             return []
 
         # Return most recent responses (sorted by timestamp descending)
-        if data:
+        if messages:
             def get_timestamp_for_sorting(item):
                 """Convert timestamp to float for consistent sorting"""
                 # Handle case where item might be a string instead of a dictionary
@@ -915,8 +916,8 @@ def get_last_10_messages(user_id, category):
                 except (ValueError, TypeError):
                     # If parsing fails, use 0
                     return 0.0
-            
-            sorted_data = sorted(data, key=get_timestamp_for_sorting, reverse=True)
+
+            sorted_data = sorted(messages, key=get_timestamp_for_sorting, reverse=True)
             last_10_messages = sorted_data[:10]
 
             logger.debug(f"Retrieved last 10 messages for user {user_id} in category {category}.")

--- a/scripts/utilities/cleanup_duplicate_messages.py
+++ b/scripts/utilities/cleanup_duplicate_messages.py
@@ -2,7 +2,7 @@
 """
 Duplicate Message Cleanup Utility
 
-This script scans all message files in the data/messages directory and removes
+This script scans all message files in the configured messages directory and removes
 duplicate messages based on identical message content. It preserves the first
 occurrence of each unique message and creates backups before making changes.
 
@@ -16,10 +16,13 @@ import argparse
 from pathlib import Path
 from datetime import datetime
 
-def find_message_files(base_dir):
-    """Find all JSON message files in the data/messages directory."""
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from core.config import MESSAGES_BY_CATEGORY_DIR_PATH
+
+def find_message_files():
+    """Find all JSON message files in the configured messages directory."""
     message_files = []
-    base_path = Path(base_dir) / "data" / "messages"
+    base_path = Path(MESSAGES_BY_CATEGORY_DIR_PATH)
     
     if not base_path.exists():
         print(f"Error: Message directory not found: {base_path}")
@@ -93,13 +96,10 @@ def create_backup(filepath):
 
 def clean_duplicates(args):
     """Main function to clean duplicates from all message files."""
-    # Get the script directory and find the project root
-    script_dir = Path(__file__).parent
-    project_root = script_dir.parent.parent  # Go up two levels from scripts/utilities
-    
-    print(f"Scanning for message files in: {project_root}")
-    
-    message_files = find_message_files(project_root)
+    print(f"Scanning for message files in: {MESSAGES_BY_CATEGORY_DIR_PATH}")
+
+    message_files = find_message_files()
+    messages_base = Path(MESSAGES_BY_CATEGORY_DIR_PATH).resolve()
     
     if not message_files:
         print("No message files found.")
@@ -113,7 +113,7 @@ def clean_duplicates(args):
     total_duplicates_removed = 0
     
     for filepath in message_files:
-        print(f"Checking: {filepath.relative_to(project_root)}")
+        print(f"Checking: {filepath.relative_to(messages_base)}")
         
         has_duplicates, total_count, duplicate_count, cleaned_data = check_duplicates_in_file(filepath)
         

--- a/scripts/utilities/cleanup_test_data.py
+++ b/scripts/utilities/cleanup_test_data.py
@@ -13,6 +13,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent))
 
 from core.logger import get_logger
+from core.config import BASE_DATA_DIR, USER_INFO_DIR_PATH
 
 logger = get_logger(__name__)
 
@@ -22,7 +23,7 @@ def get_script_dir():
 
 def cleanup_test_users():
     """Remove test user directories"""
-    users_dir = get_script_dir() / "data" / "users"
+    users_dir = Path(USER_INFO_DIR_PATH)
     
     # Test users to remove (based on the names in your list)
     test_users = [
@@ -64,7 +65,7 @@ def cleanup_backup_files():
     
     # Directories to search
     search_dirs = [
-        root_dir / "data",
+        Path(BASE_DATA_DIR),
         root_dir / "scripts"
     ]
     
@@ -167,7 +168,7 @@ def main():
         
         print("\n✅ Cleanup completed successfully!")
         print("\nYour MHM installation is now cleaner:")
-        print("• Test users removed from data/users/")
+        print(f"• Test users removed from {USER_INFO_DIR_PATH}/")
         print("• Migration and testing backup files removed")
         print("• Obsolete scripts removed from scripts/")
         print("\nOnly your real user data and active scripts remain.")

--- a/ui/ui_app.py
+++ b/ui/ui_app.py
@@ -23,6 +23,7 @@ from ui.account_manager import setup_view_edit_messages_window, setup_view_edit_
 from user.user_context import UserContext
 import core.utils
 from tkinter import ttk
+from core.config import BASE_DATA_DIR, MESSAGES_BY_CATEGORY_DIR_PATH, USER_INFO_DIR_PATH
 
 class ServiceManager:
     """Manages the MHM backend service process"""
@@ -484,7 +485,7 @@ class MHMManagerUI:
             text_widget.insert('end', f"✓ Total Users: {len(user_ids)}\n")
             
             # Check data directories
-            required_dirs = ['data', 'data/messages', 'data/user_info']
+            required_dirs = [BASE_DATA_DIR, MESSAGES_BY_CATEGORY_DIR_PATH, USER_INFO_DIR_PATH]
             for dir_path in required_dirs:
                 exists = os.path.exists(dir_path)
                 status = "✓" if exists else "✗"
@@ -494,9 +495,9 @@ class MHMManagerUI:
             text_widget.insert('end', "\nChecking for common issues...\n")
             
             # Check for orphaned message files
-            if os.path.exists('data/messages'):
+            if os.path.exists(MESSAGES_BY_CATEGORY_DIR_PATH):
                 orphaned_files = 0
-                for root, dirs, files in os.walk('data/messages'):
+                for root, dirs, files in os.walk(MESSAGES_BY_CATEGORY_DIR_PATH):
                     for file in files:
                         if file.endswith('.json'):
                             # Extract user_id from filename


### PR DESCRIPTION
## Summary
- consolidate path handling by using BASE_DATA_DIR constants
- use config paths inside UI health checks
- update cleanup scripts to rely on configured directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858f4a76a1483308a5499f41ee19a3d