### PR TITLE
docs: update communication module references

### DIFF
--- a/.cursor/rules/critical.mdc
+++ b/.cursor/rules/critical.mdc
@@ -44,7 +44,7 @@ Building a personal mental health assistant that helps manage executive function
 - `ui/ui_app_qt.py` - Admin interface (admin only)
 - `core/config.py` - Configuration
 - `core/user_data_handlers.py`, `core/user_data_validation.py` - User data management
-- `bot/` - Communication channel implementations
+- `communication/` - Communication channel implementations
 - `data/users/` - User data
 
 ### **Development Workflow**

--- a/AI_ARCHITECTURE.md
+++ b/AI_ARCHITECTURE.md
@@ -8,7 +8,7 @@
 ### **Key Modules**
 - **User data**: `core/user_data_handlers.py`, `core/user_data_validation.py`
 - **UI**: `ui/dialogs/`, `ui/widgets/`
-- **Communication**: `bot/` directory
+- **Communication**: `communication/` directory
 - **Scheduling**: `core/scheduler.py`
 - **Configuration**: `core/config.py`
 
@@ -17,9 +17,10 @@
 - `core/service.py` - Background service
 - `ui/ui_app_qt.py` - Admin interface
 - `core/user_data_handlers.py` - Unified user data access
+- `communication/core/channel_orchestrator.py` - Communication coordination
 
 ## 🏗️ Data Flow
-- **User Data**: `data/users/{user_id}/` → `core/user_data_handlers.py` → UI/Bot
+- **User Data**: `data/users/{user_id}/` → `core/user_data_handlers.py` → UI/CommunicationManager
 - **Messages**: `resources/default_messages/` → `data/users/{user_id}/messages/`
 - **UI**: `.ui` files → `ui/generated/` → `ui/dialogs/` → `ui_app_qt.py`
 

--- a/AI_REFERENCE.md
+++ b/AI_REFERENCE.md
@@ -56,10 +56,10 @@
 - `core/service.py` - Background service
 - `ui/ui_app_qt.py` - Admin interface
 - `core/user_data_handlers.py` - Unified user data access
-- `bot/communication_manager.py` - Communication coordination
+- `communication/core/channel_orchestrator.py` - Communication coordination
 
 ### **Data Flow Patterns**
-- **User Data**: `data/users/{user_id}/` → `core/user_data_handlers.py` → UI/Bot
+- **User Data**: `data/users/{user_id}/` → `core/user_data_handlers.py` → UI/CommunicationManager
 - **Messages**: `resources/default_messages/` → `data/users/{user_id}/messages/`
 - **Configuration**: `.env` → `core/config.py` → Application
 

--- a/AI_SESSION_STARTER.md
+++ b/AI_SESSION_STARTER.md
@@ -56,7 +56,7 @@ Personal mental health assistant that helps manage executive functioning deficit
 - `ui/ui_app_qt.py` - Admin interface (admin only)
 - `core/config.py` - Configuration
 - `core/user_data_handlers.py`, `core/user_data_validation.py` - User data management
-- `bot/` - Communication channel implementations
+- `communication/` - Communication channel implementations
 - `data/users/` - User data
 
 ## 📊 **CURRENT SYSTEM STATUS**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,13 +12,13 @@
 ### **Key Modules Decision Tree**
 1. **User data access?** → `core/user_data_handlers.py`, `core/user_data_validation.py`
 2. **UI components?** → `ui/dialogs/`, `ui/widgets/`
-3. **Communication?** → `bot/` directory
+3. **Communication?** → `communication/` directory
 4. **Scheduling?** → `core/scheduler.py`, `core/schedule_management.py`
 5. **Configuration?** → `core/config.py`
 6. **Testing?** → `tests/` directory
 
 ### **Data Flow Patterns**
-- **User Data**: `data/users/{user_id}/` → `core/user_data_handlers.py` → UI/Bot
+- **User Data**: `data/users/{user_id}/` → `core/user_data_handlers.py` → UI/CommunicationManager
 - **Messages**: `resources/default_messages/` → `data/users/{user_id}/messages/`
 - **Configuration**: `.env` → `core/config.py` → Application
 - **UI**: `.ui` files → `ui/generated/` → `ui/dialogs/` → `ui_app_qt.py`
@@ -28,16 +28,16 @@
 - `core/service.py` - Background service
 - `ui/ui_app_qt.py` - Admin interface
 - `core/user_data_handlers.py` - Unified user data access
-- `bot/communication_manager.py` - Communication coordination
+- `communication/core/channel_orchestrator.py` - Communication coordination
 
 ---
 
 ## Directory Structure & Key Modules
 
 - **ai_tools/**: AI collaboration tools, audit scripts, and documentation management
-- **bot/**: Messaging and communication bots (Discord, Email, Telegram, etc.)
+- **communication/**: Messaging channels and orchestration (Discord, Email, etc.)
 - **core/**: Core logic, utilities, configuration, scheduling, analytics, and data management
-- **custom_data/**: User data storage with backups and user index
+- **ai/**: Local AI integration modules
 - **data/**: User data storage (per-user subdirectories: account.json, preferences.json, schedules.json, etc.)
 - **resources/default_messages/**: Default motivational, health, and other message templates
 - **resources/**: Application resources and presets
@@ -104,7 +104,7 @@
 - **user/user_preferences.py**: (Planned) Class-based interface for managing user preferences.
 - **ui/ui_app_qt.py**: Main PySide6/Qt UI application, user selection, and admin panel.
 - **ui/dialogs/**: Dialog implementations for account creation, user management, etc.
-- **bot/**: Messaging bots for different platforms, using user data for personalized interactions.
+- **communication/**: Messaging channels for different platforms, using user data for personalized interactions.
 - **core/scheduler.py**: Scheduling logic for reminders, check-ins, and message delivery. Includes intelligent task reminder scheduling with random task selection and timing.
 - **core/checkin_analytics.py**: Analytics and insights on user check-in data.
 

--- a/PLANS.md
+++ b/PLANS.md
@@ -322,14 +322,14 @@
 **Effort**: Medium  
 **Dependencies**: None  
 
-**Objective**: Improve clarity and separation of purposes for bot modules.
+**Objective**: Improve clarity and separation of purposes for communication modules.
 
 **Target Modules**:
-- `bot/communication_manager.py`
-- `bot/conversation_manager.py`
-- `bot/enhanced_command_parser.py`
-- `bot/interaction_handlers.py`
-- `bot/interaction_manager.py`
+- `communication/core/channel_orchestrator.py`
+- `communication/message_processing/conversation_flow_manager.py`
+- `communication/command_handlers/interaction_handlers.py`
+- `communication/message_processing/interaction_manager.py`
+- `communication/command_handlers/` (command parsing & dispatch)
 
 **Investigation Plan**:
 - [ ] Analyze current module purposes and responsibilities
@@ -386,7 +386,7 @@ def validate_and_accept(self):
 - [x] Refactor `ui/dialogs/account_creator_dialog.py` (12 helper functions)
 - [x] Refactor `core/user_data_handlers.py` (6 helper functions)
 - [x] Refactor `core/file_operations.py` (6 helper functions)
-- [x] Refactor `bot/interaction_handlers.py` (6 helper functions)
+- [x] Refactor `communication/command_handlers/interaction_handlers.py` (6 helper functions)
 - [x] Refactor `tests/test_utilities.py` (8 helper functions)
 
 **Phase 2B: Extended Refactoring** ✅ **COMPLETED**
@@ -512,11 +512,11 @@ def validate_and_accept(self):
 
 **Files Modified**:
 - `core/config.py`: Added `get_available_channels()` and `get_channel_class_mapping()` functions
-- `bot/channel_factory.py`: Updated to use config-based auto-registration
+- `communication/core/factory.py`: Updated to use config-based auto-registration
 - `core/service.py`: Removed channel registry import and registration
 - `ui/ui_app_qt.py`: Removed channel registry import and registration
 - `tests/ui/test_dialogs.py`: Removed channel registry import and registration
-- `bot/channel_registry.py`: **DELETED** - No longer needed
+- `communication/core/channel_registry.py`: **DELETED** - No longer needed
 
 **Benefits Realized**:
 - **Reduced Complexity**: Eliminated redundant registration system
@@ -662,7 +662,7 @@ def validate_and_accept(self):
   - [x] Updated `tests/integration/test_account_management.py` and `tests/ui/test_dialogs.py`
   - [x] Removed incompatible `main()` functions from test files
 - [x] **Fixed AsyncIO Deprecation Warnings** ✅ **COMPLETED**
-  - [x] Updated `bot/ai_chatbot.py`, `bot/email_bot.py`, `bot/communication_manager.py`
+- [x] Updated `ai/chatbot.py`, `communication/communication_channels/email/bot.py`, `communication/core/channel_orchestrator.py`
   - [x] Replaced `asyncio.get_event_loop()` with `asyncio.get_running_loop()` with fallback
 - [x] **Enhanced Account Validation** ✅ **COMPLETED**
   - [x] Added strict validation for empty `internal_username` fields
@@ -1141,13 +1141,13 @@ Note: Telegram integration has been removed from scope.
 **Timeline**: Complete by 2025-08-15
 
 ### 6. Discord Bot Legacy Methods ⚠️ **LOW PRIORITY**
-**Location**: `bot/discord_bot.py`
+**Location**: `communication/communication_channels/discord/bot.py`
 **Issue**: Legacy methods for backward compatibility
 **Legacy Code Found**: Lines 518-564: Legacy start/stop methods
 **Timeline**: Complete by 2025-08-15
 
 ### 7. Communication Manager Legacy Wrappers ⚠️ **HIGH PRIORITY**
-**Location**: `bot/communication_manager.py`
+**Location**: `communication/core/channel_orchestrator.py`
 **Issue**: LegacyChannelWrapper and legacy channel access
 **Legacy Code Found**:
 - `LegacyChannelWrapper` class (Lines 1064-1216): Complete legacy wrapper
@@ -1195,7 +1195,8 @@ MHM/
 │   ├── dialogs/            # Dialog implementations
 │   ├── widgets/            # Reusable widget components
 │   └── ui_app_qt.py        # Main admin interface (PySide6)
-├── bot/                    # Communication channel implementations
+├── communication/          # Communication channel implementations
+├── ai/                     # AI conversation modules
 ├── tasks/                  # Task management system
 ├── user/                   # User context and preferences
 ├── data/                   # User data storage

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See **HOW_TO_RUN.md** for more details.
 - **DOCUMENTATION_GUIDE.md** - Documentation organization and standards
 
 ### Documentation Categories
-- **🤖 AI-Focused**: `AI_RULES.md` and `.cursor/rules/` - For AI assistants
+- **🤖 AI-Focused**: `AI_SESSION_STARTER.md` and `.cursor/rules/` - For AI assistants
 - **👤 User-Focused**: Development guides and references - For human developers
 - **🔧 Configuration**: `requirements.txt`, `.env` - For both
 
@@ -83,9 +83,9 @@ If LM Studio is installed with a compatible model, MHM can provide local AI chat
 ```
 MHM/
 ├── ai_tools/    # AI collaboration tools and audit scripts
-├── bot/         # Communication handlers
+├── communication/ # Messaging channels and orchestration
 ├── core/        # Backend service (refactored into focused modules)
-├── custom_data/ # User data with backups and user index
+├── ai/          # Local AI chat integration
 ├── data/        # User data (gitignored)
 ├── resources/   # Application resources and presets
 │   └── default_messages/

--- a/TEST_COVERAGE_EXPANSION_PLAN.md
+++ b/TEST_COVERAGE_EXPANSION_PLAN.md
@@ -49,7 +49,7 @@
 - **Results**: Created comprehensive test suite with 30 behavior tests covering all User Profile Dialog functionality
 
 ### **3. Communication Manager (24% → 61%) ✅ COMPLETED**
-**File**: `bot/communication_manager.py` (319 lines uncovered)
+**File**: `communication/core/channel_orchestrator.py` (coverage pending update)
 - **Why Critical**: Core communication infrastructure
 - **Current Status**: 61% coverage (excellent)
 - **Target**: 60% coverage ✅ ACHIEVED
@@ -77,7 +77,7 @@
 - **Results**: Created comprehensive behavior test suite with 37 tests covering scheduler lifecycle, message scheduling, task reminders, time management, and error handling
 
 ### **5. Interaction Handlers (32% → 49%) ✅ COMPLETED**
-**File**: `bot/interaction_handlers.py` (591 lines uncovered)
+**File**: `communication/command_handlers/interaction_handlers.py` (coverage pending update)
 - **Why Critical**: Handles all user interactions
 - **Current Status**: 49% coverage (+17% improvement)
 - **Target**: 60% coverage (nearly achieved)
@@ -129,8 +129,8 @@
   - [x] Test widget integration and performance
 - **Results**: Created comprehensive test suite with 41 behavior tests covering all widget functionality, real behavior testing, and proper UI mocking
 
-### **3. Enhanced Command Parser (40% → 70%)**
-**File**: `bot/enhanced_command_parser.py` (155 lines uncovered)
+### **3. Command Handling Framework (40% → 70%)**
+**File**: `communication/command_handlers/` modules (coverage pending update)
 - **Why Important**: Natural language processing
 - **Current Status**: 40% coverage
 - **Target**: 70% coverage
@@ -143,7 +143,7 @@
   - [ ] Test edge cases and boundary conditions
 
 ### **4. Email Bot (37% → 60%)**
-**File**: `bot/email_bot.py` (72 lines uncovered)
+**File**: `communication/communication_channels/email/bot.py` (coverage pending update)
 - **Why Important**: Email communication channel
 - **Current Status**: 37% coverage
 - **Target**: 60% coverage

--- a/TODO.md
+++ b/TODO.md
@@ -330,7 +330,7 @@ When adding new tasks, follow this format:
     - [x] Updated `tests/integration/test_account_management.py` and `tests/ui/test_dialogs.py`
     - [x] Removed incompatible `main()` functions from test files
   - [x] **Fixed AsyncIO Deprecation Warnings** ✅ **COMPLETED**
-    - [x] Updated `bot/ai_chatbot.py`, `bot/email_bot.py`, `bot/communication_manager.py`
+    - [x] Updated `ai/chatbot.py`, `communication/communication_channels/email/bot.py`, `communication/core/channel_orchestrator.py`
     - [x] Replaced `asyncio.get_event_loop()` with `asyncio.get_running_loop()` with fallback
   - [x] **Enhanced Account Validation** ✅ **COMPLETED**
     - [x] Added strict validation for empty `internal_username` fields
@@ -584,7 +584,7 @@ When adding new tasks, follow this format:
   - [ ] Extend schema validation to schedules save paths not yet using helpers (confirm all call-sites)
   - [ ] Add unit tests for `validate_*_dict` helpers with edge-case payloads (extras, nulls, invalid times/days)
   - [ ] Add behavior tests for end-to-end save/load normalization
-  - [ ] Add read-path normalization invocation to remaining reads that feed business logic (sweep `core/` and `bot/`)
+  - [ ] Add read-path normalization invocation to remaining reads that feed business logic (sweep `core/` and `communication/`)
 
 **Discord Task Edit Follow-ups and Suggestion Relevance**
 - *What it means*: Ensure edit-task prompts are actionable, suppress irrelevant suggestions, and add coverage for common follow-ups

--- a/logs/LOGGING_GUIDE.md
+++ b/logs/LOGGING_GUIDE.md
@@ -127,7 +127,7 @@ discord_logger = ComponentLogger('discord', LOG_DISCORD_FILE, level=logging.DEBU
 
 ### 2. BaseChannel pattern (standardized)
 - Subclasses do not set their own loggers.
-- `bot/base_channel.py` assigns `self.logger = get_component_logger(self.config.name)`.
+- `communication/communication_channels/base/base_channel.py` assigns `self.logger = get_component_logger(self.config.name)`.
 - Channel classes should ensure `config.name` matches the component (`discord`, `email`, `telegram`).
 
 ### 3. Test isolation behavior

--- a/tests/README.md
+++ b/tests/README.md
@@ -389,7 +389,7 @@ When running tests with coverage, reports are generated in:
 - **Terminal Report**: Shows missing lines in terminal output
 
 ### **Coverage Targets**
-- **Core Modules**: `core/`, `bot/`, `tasks/`, `user/`
+- **Core Modules**: `core/`, `communication/`, `ai/`, `tasks/`, `user/`
 - **Target Coverage**: 80%+ for critical modules
 - **Current Coverage**: 29% of codebase (9 out of 31+ modules)
 


### PR DESCRIPTION
## Summary
- Replace `bot/` mentions with `communication/` and `ai/` across README, architecture docs, and AI guides
- Refresh documentation plans and TODO items with current module paths
- Clarify logging and testing docs for new communication architecture

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b574891f64833094aba8ccb5c6e5ba