### PR TITLE
test: force offscreen Qt platform

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ This file provides:
 
 import pytest
 import os
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
 import tempfile
 import shutil
 import json


### PR DESCRIPTION
## Summary
- ensure `QT_QPA_PLATFORM` defaults to `offscreen` during tests so Qt widgets can render headlessly

## Testing
- `pytest tests/ui -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67d6120988330b15fbc01d07e8543